### PR TITLE
Improve Rust example

### DIFF
--- a/examples/messaging/pub-sub/rust/main.rs
+++ b/examples/messaging/pub-sub/rust/main.rs
@@ -5,28 +5,23 @@ use std::{env, str::from_utf8};
 async fn main() -> Result<(), async_nats::Error> {
     // Use the NATS_URL env variable if defined, otherwise fallback
     // to the default.
-    let nats_url = env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string());
+    let nats_url = env::var("NATS_URL")
+        .unwrap_or_else(|_| "nats://localhost:4222".to_string());
 
     let client = async_nats::connect(nats_url).await?;
 
     // Publish a message to the subject `greet.joe`.
-    client
-        .publish("greet.joe".to_string(), "hello".into())
-        .await?;
+    client.publish("greet.joe".into(), "hello".into()).await?;
 
     // `Subscriber` implements Rust iterator, so we can leverage
     // combinators like `take()` to limit the messages intended
     // to be consumed for this interaction.
-    let mut subscription = client
-        .subscribe("greet.*".to_string())
-        .await?
-        .take(3);
+    let mut subscription =
+        client.subscribe("greet.*".to_string()).await?.take(3);
 
     // Publish to three different subjects matching the wildcard.
     for subject in ["greet.sue", "greet.bob", "greet.pam"] {
-        client
-            .publish(subject.to_string(), "hello".into())
-            .await?;
+        client.publish(subject.into(), "hello".into()).await?;
     }
 
     // Notice that the first message received is `greet.sue` and not
@@ -35,9 +30,12 @@ async fn main() -> Result<(), async_nats::Error> {
     // must be connected showing *interest* in a subject for the server to
     // relay the message to the client.
     while let Some(message) = subscription.next().await {
-        println!("{:?} received on {:?}", from_utf8(&message.payload), &message.subject);
+        println!(
+            "{:?} received on {:?}",
+            from_utf8(&message.payload),
+            &message.subject
+        );
     }
 
     Ok(())
 }
-


### PR DESCRIPTION
This sets line width to 80 characters.
It also uses `into()` instead of `to_string()` as `nats.rs`  repo will soon get `subject` type soon, and I realized that `Into` trait will play nicer with it (will not add unnecessary alloc) without any changes to the code of users, despite changes in the API.
